### PR TITLE
fixed update_url method for PrerenderHosted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ README.html
 
 shelf.db
 .idea/*
+venv

--- a/django_seo_js/backends/prerender.py
+++ b/django_seo_js/backends/prerender.py
@@ -77,3 +77,14 @@ class PrerenderHosted(PrerenderIO):
 
     def _get_token(self):
         pass
+
+    def update_url(self, url=None):
+        """
+        Accepts a fully-qualified url.
+        Returns True if successful, False if not successful.
+        """
+        if not url:
+            raise ValueError("Neither a url or regex was provided to update_url.")
+        post_url = "%s%s" % (self.BASE_URL, url)
+        r = self.requests.post(post_url)
+        return int(r.status_code) < 500

--- a/django_seo_js/tests/backends/test_prerender_hosted.py
+++ b/django_seo_js/tests/backends/test_prerender_hosted.py
@@ -86,16 +86,11 @@ class PrerenderHostedTestMethods(TestCase):
             resp = self.backend.get_response_for_url("http://www.example.com")
             self.assertEqual(MOCK_GIANT_RESPONSE, resp.content)
 
-    def test_update_url_with_url_only(self):
+    def test_update_url_with_url(self):
         with HTTMock(mock_prerender_recache_response):
             resp = self.backend.update_url(url="http://www.example.com")
             self.assertEqual(resp, True)
 
-    def test_update_url_with_regex_only(self):
-        with HTTMock(mock_prerender_recache_response):
-            resp = self.backend.update_url(regex="http://www.example.com/*")
-            self.assertEqual(resp, True)
-
-    def test_update_url_missing_url_and_regex(self):
+    def test_update_url_missing_url(self):
         with HTTMock(mock_prerender_recache_response):
             self.assertRaises(ValueError, self.backend.update_url)


### PR DESCRIPTION
I finally created the pull request we discussed in https://github.com/skoczen/django-seo-js/issues/6 :
* fixed the update_url method for PrerenderHosted,
* removed the feature to update by regex in that case because according to the public repo this doesn't seem to be possible
* updated the tests accordingly