### PR TITLE
Support building custom URL for prerendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ def listing_changed(sender, instance, created, **kwargs):
 post_save.connect(listing_changed, sender=Listing)
 ```
 
+## Building your own URLs for prerendering
+
+If you need to customize the fully-qualified URL, you can subclass any backend and override the `build_absolute_uri()` method.
+
+```python
+class MyBackend(SEOBackendBase):
+    def build_absolute_uri(self, request):
+        """Strip out all query params:"""
+        return '{scheme}://{host}{path}'.format(
+            scheme=self.scheme,
+            host=self.get_host(),
+            path=self.path,
+        )
+```
+
 
 # How it all works
 

--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -22,6 +22,23 @@ class SelectedBackend(object):
 class SEOBackendBase(object):
     """The base class to inherit for SEO_JS backends"""
 
+    def build_absolute_uri(self, request):
+        """
+        Return the fully-qualified url that will be pre-rendered.
+
+        Override to customize how your URIs are built.
+
+        e.g. to strip out all query params:
+        ```
+        return '{scheme}://{host}{path}'.format(
+            scheme=self.scheme,
+            host=self.get_host(),
+            path=self.path,
+        )
+        ```
+        """
+        return request.build_absolute_uri()
+
     def get_response_for_url(self, url):
         """
         Accepts a fully-qualified url.

--- a/django_seo_js/middleware/hashbang.py
+++ b/django_seo_js/middleware/hashbang.py
@@ -17,7 +17,7 @@ class HashBangMiddleware(SelectedBackend):
         if "_escaped_fragment_" not in request.GET:
             return
 
-        url = self.backend.build_absolute_uri()
+        url = self.backend.build_absolute_uri(request)
         try:
             return self.backend.get_response_for_url(url)
         except Exception as e:

--- a/django_seo_js/middleware/hashbang.py
+++ b/django_seo_js/middleware/hashbang.py
@@ -17,7 +17,7 @@ class HashBangMiddleware(SelectedBackend):
         if "_escaped_fragment_" not in request.GET:
             return
 
-        url = request.build_absolute_uri()
+        url = self.backend.build_absolute_uri()
         try:
             return self.backend.get_response_for_url(url)
         except Exception as e:

--- a/django_seo_js/middleware/useragent.py
+++ b/django_seo_js/middleware/useragent.py
@@ -27,7 +27,7 @@ class UserAgentMiddleware(SelectedBackend):
         if not self.USER_AGENT_REGEX.match(request.META["HTTP_USER_AGENT"]):
             return
 
-        url = request.build_absolute_uri()
+        url = self.backend.build_absolute_uri()
         try:
             return self.backend.get_response_for_url(url)
         except Exception as e:

--- a/django_seo_js/middleware/useragent.py
+++ b/django_seo_js/middleware/useragent.py
@@ -27,7 +27,7 @@ class UserAgentMiddleware(SelectedBackend):
         if not self.USER_AGENT_REGEX.match(request.META["HTTP_USER_AGENT"]):
             return
 
-        url = self.backend.build_absolute_uri()
+        url = self.backend.build_absolute_uri(request)
         try:
             return self.backend.get_response_for_url(url)
         except Exception as e:


### PR DESCRIPTION
We're needing to remove utm_* params and other query string params from the URLs we're building. Instead of overriding the request object's `build_absolute_uri` method, it makes sense to give custom backends a hook into how the URLs are constructed. The default is current behavior, so this is fully backwards compatible.