### PR TITLE
Add support for sending User-Agent string to prerenderer and fix breaking headers issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ mattrobenolt - https://github.com/mattrobenolt
 thoop - https://github.com/thoop
 rchrd2 - https://github.com/rchrd2
 chazcb - https://github.com/chazcb
+jdotjdot - https://github.com/jdotjdot

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ SEO_JS_IGNORE_EXTENSIONS = [
     ".txt",
     # See helpers.py for full list of extensions ignored by default.
 ]
+
+# Whether or not to pass along the original request's user agent to the prerender service. 
+# Useful for analytics, understanding where requests are coming from.
+SEO_JS_SEND_USER_AGENT = True
 ```
 
 ## Backend settings
@@ -135,9 +139,10 @@ Backends must implement the following methods:
 
 class MyBackend(SEOBackendBase):
 
-    def get_response_for_url(self, url):
+    def get_response_for_url(self, url, request=None):
         """
         Accepts a fully-qualified url.
+        Optionally accepts the django request object, so that headers, etc. may be passed along to the prerenderer.
         Returns an HttpResponse, passing through all headers and the status code.
         """
         raise NotImplementedError

--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -63,7 +63,7 @@ class RequestsBasedBackend(object):
     def build_django_response_from_requests_response(self, response):
         r = HttpResponse(response.content)
         for k, v in response.headers.items():
-            if k not in IGNORED_HEADERS:
+            if k.lower() not in IGNORED_HEADERS:
                 r[k] = v
         r['content-length'] = len(response.content)
         r.status_code = response.status_code

--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -39,7 +39,7 @@ class SEOBackendBase(object):
         """
         return request.build_absolute_uri()
 
-    def get_response_for_url(self, url):
+    def get_response_for_url(self, url, request=None):
         """
         Accepts a fully-qualified url.
         Returns an HttpResponse, passing through all headers and the status code.

--- a/django_seo_js/backends/prerender.py
+++ b/django_seo_js/backends/prerender.py
@@ -16,7 +16,7 @@ class PrerenderIO(SEOBackendBase, RequestsBasedBackend):
             raise ValueError("Missing SEO_JS_PRERENDER_TOKEN in settings.")
         return settings.PRERENDER_TOKEN
 
-    def get_response_for_url(self, url):
+    def get_response_for_url(self, url, request=None):
         """
         Accepts a fully-qualified url.
         Returns an HttpResponse, passing through all headers and the status code.
@@ -29,6 +29,9 @@ class PrerenderIO(SEOBackendBase, RequestsBasedBackend):
         headers = {
             'X-Prerender-Token': self.token,
         }
+        if request and settings.SEND_USER_AGENT:
+            headers.update({'User-Agent': request.META.get('HTTP_USER_AGENT')})
+
         r = self.session.get(render_url, headers=headers, allow_redirects=False)
         assert r.status_code < 500
 

--- a/django_seo_js/middleware/escaped_fragment.py
+++ b/django_seo_js/middleware/escaped_fragment.py
@@ -19,7 +19,7 @@ class EscapedFragmentMiddleware(SelectedBackend):
 
         url = self.backend.build_absolute_uri(request)
         try:
-            return self.backend.get_response_for_url(url)
+            return self.backend.get_response_for_url(url, request)
         except Exception as e:
             logger.exception(e)
 

--- a/django_seo_js/middleware/useragent.py
+++ b/django_seo_js/middleware/useragent.py
@@ -29,6 +29,6 @@ class UserAgentMiddleware(SelectedBackend):
 
         url = self.backend.build_absolute_uri(request)
         try:
-            return self.backend.get_response_for_url(url)
+            return self.backend.get_response_for_url(url, request)
         except Exception as e:
             logger.exception(e)

--- a/django_seo_js/settings.py
+++ b/django_seo_js/settings.py
@@ -71,3 +71,5 @@ BACKEND = getattr(django_settings, 'SEO_JS_BACKEND', 'django_seo_js.backends.Pre
 PRERENDER_TOKEN = getattr(django_settings, 'SEO_JS_PRERENDER_TOKEN', None)
 PRERENDER_URL = getattr(django_settings, 'SEO_JS_PRERENDER_URL', None)
 PRERENDER_RECACHE_URL = getattr(django_settings, 'SEO_JS_PRERENDER_RECACHE_URL', None)
+
+SEND_USER_AGENT = getattr(django_settings, 'SEO_JS_SEND_USER_AGENT', True)


### PR DESCRIPTION
Makes changes to argument signature of the BackendBase method get_response_for_url()

I've updated the README accordingly as well.  I have not been able to get the tests running correctly on my computer to check them&mdash;all of the tests are failing for me, even the tests that are completely unrelated to any changes.

I reviewed pretty thoroughly though and don't think there should be any issues; I changed very little.

I wanted to do this because I use Prerender.io but all of the requests look like they're coming from python's `requests` module, and I'd love for Prerender.io to show the actual user agent so I can get better analytics on where crawler requests are coming from.
