### PR TITLE
Fix error for Headers of format 'Connection'

### DIFF
--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -63,7 +63,7 @@ class RequestsBasedBackend(object):
     def build_django_response_from_requests_response(self, response):
         r = HttpResponse(response.content)
         for k, v in response.headers.items():
-            if k not in IGNORED_HEADERS:
+            if k.lower() not in IGNORED_HEADERS:
                 r[k] = v
         r['content-length'] = len(response.content)
         r.status_code = response.status_code


### PR DESCRIPTION
This fixes the "AssertionError: Hop-by-hop headers not allowed" error that occurs when trying to share your urls on facebook/twitter etc...