### PR TITLE
Add SEO_JS_PRERENDER_TIMEOUT functionality

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ mattrobenolt - https://github.com/mattrobenolt
 thoop - https://github.com/thoop
 rchrd2 - https://github.com/rchrd2
 chazcb - https://github.com/chazcb
+clifff - https://github.com/clifff

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ To use [prerender.io](http://prerender.io),
 ```python
 # Prerender.io token
 SEO_JS_PRERENDER_TOKEN = "123456789abcdefghijkl"
+
+# Optional timeout option (following requests timeout format)
+SEO_JS_PRERENDER_TIMEOUT = (5,5)
 ```
 
 You don't need to set `SEO_JS_BACKEND`, since it defaults to `"django_seo_js.backends.PrerenderIO"`.

--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -68,3 +68,8 @@ class RequestsBasedBackend(object):
         r['content-length'] = len(response.content)
         r.status_code = response.status_code
         return r
+
+    def build_request_timeout_response(self):
+        r = HttpResponse()
+        r.status_code = 408
+        return r

--- a/django_seo_js/settings.py
+++ b/django_seo_js/settings.py
@@ -69,5 +69,6 @@ USER_AGENTS = frozenset(getattr(django_settings, 'SEO_JS_USER_AGENTS', (
 BACKEND = getattr(django_settings, 'SEO_JS_BACKEND', 'django_seo_js.backends.PrerenderIO')
 
 PRERENDER_TOKEN = getattr(django_settings, 'SEO_JS_PRERENDER_TOKEN', None)
+PRERENDER_TIMEOUT = getattr(django_settings, 'SEO_JS_PRERENDER_TIMEOUT', False)
 PRERENDER_URL = getattr(django_settings, 'SEO_JS_PRERENDER_URL', None)
 PRERENDER_RECACHE_URL = getattr(django_settings, 'SEO_JS_PRERENDER_RECACHE_URL', None)

--- a/django_seo_js/tests/backends/test_prerender_io.py
+++ b/django_seo_js/tests/backends/test_prerender_io.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from httmock import all_requests, HTTMock
+from mock import MagicMock
+import requests
 
 from django_seo_js.tests.utils import override_settings
 from django_seo_js.backends import PrerenderIO
@@ -41,6 +43,23 @@ class PrerenderIOTestToken(TestCase):
         self.assertEqual(self.backend._get_token(), "123124341adfsaf")
         # Test __init__
         self.assertEqual(self.backend.token, "123124341adfsaf")
+
+
+class PrerenderTimeout(TestCase):
+
+    @override_settings(PRERENDER_TIMEOUT=5)
+    def test_timeout_setting(self):
+        self.backend = PrerenderIO()
+        self.assertEqual(self.backend._request_kwargs({}), {'timeout': 5})
+
+    @override_settings(PRERENDER_TIMEOUT=5)
+    def test_timeout_response(self):
+        self.backend = PrerenderIO()
+        self.backend.session.get = MagicMock(
+            side_effect=requests.exceptions.Timeout()
+        )
+        resp = self.backend.get_response_for_url("http://www.example.com")
+        self.assertEqual(resp.status_code, 408)
 
 
 class PrerenderIOTestMethods(TestCase):


### PR DESCRIPTION
I've been seeing some very slow interactions with prerender.io (up to 59 seconds) in New Relic recently, so I wanted to add a timeout option to prevent the application server from being tied up for that long. In the case that the timeout is hit, a 408 response is returned, so the seo bot should try again later and hopefully have better luck.