### PR TITLE
Support for Python 3 and Django 1.9+ (plus Tox)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ mattrobenolt - https://github.com/mattrobenolt
 thoop - https://github.com/thoop
 rchrd2 - https://github.com/rchrd2
 chazcb - https://github.com/chazcb
+Pi Delport - https://github.com/pjdelport

--- a/django_seo_js/backends/prerender.py
+++ b/django_seo_js/backends/prerender.py
@@ -1,5 +1,5 @@
 from django_seo_js import settings
-from base import SEOBackendBase, RequestsBasedBackend
+from .base import SEOBackendBase, RequestsBasedBackend
 
 
 class PrerenderIO(SEOBackendBase, RequestsBasedBackend):

--- a/django_seo_js/backends/test.py
+++ b/django_seo_js/backends/test.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
 
-from base import SEOBackendBase
+from .base import SEOBackendBase
 
 
 class TestBackend(SEOBackendBase):

--- a/django_seo_js/templatetags/django_seo_js.py
+++ b/django_seo_js/templatetags/django_seo_js.py
@@ -1,7 +1,9 @@
 from django import template
+from django.utils.safestring import mark_safe
+
 register = template.Library()
 
 
 @register.simple_tag
 def seo_js_head(*args):
-    return """<meta name="fragment" content="!">"""
+    return mark_safe("""<meta name="fragment" content="!">""")

--- a/django_seo_js/tests/backends/test_prerender_hosted.py
+++ b/django_seo_js/tests/backends/test_prerender_hosted.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import random
 import string
 
@@ -7,11 +9,12 @@ from httmock import all_requests, HTTMock
 from django_seo_js.tests.utils import override_settings
 from django_seo_js.backends import PrerenderHosted
 
-MOCK_RESPONSE = "<html><body><h1>Hello, World!</h1></body></html>"
+MOCK_RESPONSE = b"<html><body><h1>Hello, World!</h1></body></html>"
 MOCK_RESPONSE_HEADERS = {"foo": "bar"}
 MOCK_RECACHE_RESPONSE = "OK"
 MOCK_RECACHE_HEADERS = {"ibbity": "ack"}
-MOCK_GIANT_RESPONSE = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(200000))
+_ascii = string.ascii_uppercase + string.digits
+MOCK_GIANT_RESPONSE = ''.join(random.choice(_ascii) for _ in range(200000)).encode('ascii')
 
 
 @all_requests

--- a/django_seo_js/tests/backends/test_prerender_io.py
+++ b/django_seo_js/tests/backends/test_prerender_io.py
@@ -1,10 +1,12 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 from httmock import all_requests, HTTMock
 
 from django_seo_js.tests.utils import override_settings
 from django_seo_js.backends import PrerenderIO
 
-MOCK_RESPONSE = "<html><body><h1>Hello, World!</h1></body></html>"
+MOCK_RESPONSE = b"<html><body><h1>Hello, World!</h1></body></html>"
 MOCK_RESPONSE_HEADERS = {"foo": "bar"}
 MOCK_RECACHE_RESPONSE = "OK"
 MOCK_RECACHE_HEADERS = {"ibbity": "ack"}

--- a/django_seo_js/tests/test_middlewares.py
+++ b/django_seo_js/tests/test_middlewares.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django_seo_js.tests.utils import override_settings
 from django_seo_js.middleware import EscapedFragmentMiddleware, UserAgentMiddleware, HashBangMiddleware
 
-print override_settings
+print(override_settings)
 
 
 class BaseMiddlewareTest(TestCase):

--- a/django_seo_js/tests/test_middlewares.py
+++ b/django_seo_js/tests/test_middlewares.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from mock import Mock
 from django.test import TestCase
 
@@ -23,7 +25,7 @@ class EscapedFragmentMiddlewareTest(TestCase):
 
     def test_has_escaped_fragment(self):
         self.request.GET = {"_escaped_fragment_": None}
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
     def test_does_not_have_escaped_fragment(self):
         self.request.GET = {}
@@ -57,7 +59,7 @@ class EscapedFragmentMiddlewareTest(TestCase):
         self.middleware = EscapedFragmentMiddleware()
         self.request.path = "/sitemap.xml"
         self.request.GET = {"_escaped_fragment_": None}
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
         self.request.path = "/foo.html"
         self.assertEqual(self.middleware.process_request(self.request), None)
@@ -80,7 +82,7 @@ class EscapedFragmentMiddlewareTest(TestCase):
         self.middleware = EscapedFragmentMiddleware()
         self.request.path = "/foo.gif"
         self.request.GET = {"_escaped_fragment_": None}
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
         self.request.path = "/foo.html"
         self.assertEqual(self.middleware.process_request(self.request), None)
@@ -115,7 +117,7 @@ class UserAgentMiddlewareTest(TestCase):
             "HTTP_USER_AGENT":
             "Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://about.ask.com/en/docs/about/webmasters.shtml)"
         }
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
     def test_does_not_match_one_of_the_default_user_agents(self):
         self.request.META = {
@@ -132,7 +134,7 @@ class UserAgentMiddlewareTest(TestCase):
         self.request.META = {
             "HTTP_USER_AGENT": "The TestUserAgent v1.0"
         }
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
     @override_settings(
         USER_AGENTS=["TestUserAgent", ],
@@ -194,7 +196,7 @@ class UserAgentMiddlewareTest(TestCase):
             "HTTP_USER_AGENT":
             "Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://about.ask.com/en/docs/about/webmasters.shtml)"
         }
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
         self.request.path = "/foo.html"
         self.assertEqual(self.middleware.process_request(self.request), None)
@@ -223,7 +225,7 @@ class UserAgentMiddlewareTest(TestCase):
             "HTTP_USER_AGENT":
             "Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://about.ask.com/en/docs/about/webmasters.shtml)"
         }
-        self.assertEqual(self.middleware.process_request(self.request).content, "Test")
+        self.assertEqual(self.middleware.process_request(self.request).content, b"Test")
 
         self.request.path = "/foo.html"
         self.assertEqual(self.middleware.process_request(self.request), None)

--- a/django_seo_js/tests/test_pep8.py
+++ b/django_seo_js/tests/test_pep8.py
@@ -18,6 +18,7 @@ class TestCodeFormat(unittest.TestCase):
         ignored_folders = [
             ".git",
             "venv",
+            ".tox",
         ]
 
         pep8style = pep8.StyleGuide(

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -1,4 +1,3 @@
-django
 fabric
 httmock
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django
-requests==2.2.1
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+Django
 requests==2.2.1

--- a/settings.py
+++ b/settings.py
@@ -14,10 +14,12 @@ DATABASES = {
 }
 
 SECRET_KEY = 'alksjdf93jqpijsdaklfjq;3lejqklejlakefjas'
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django_seo_js.middleware.EscapedFragmentMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py{27,35}-dj1.{8,9,10}
+
+[testenv]
+deps =
+    -rrequirements.tests.txt
+
+    dj1.8: Django ~=1.8.0
+    dj1.9: Django ~=1.9.0
+    dj1.10: Django ~=1.10.0
+
+commands =
+    {envpython} manage.py test


### PR DESCRIPTION
This makes the test suite pass on 2.7 + 3.5, and Django 1.8 – 1.10.

This also adds a Tox configuration that will test all combinations of the above.
