### PR TITLE
Patch for Django 4.1 support.

### DIFF
--- a/django_seo_js/backends/__init__.py
+++ b/django_seo_js/backends/__init__.py
@@ -1,3 +1,3 @@
-from .base import SelectedBackend, SEOBackendBase
+from .base import SelectedBackend, SelectedBackendMixin, SEOBackendBase
 from .prerender import PrerenderHosted, PrerenderIO
 from .test import TestBackend, TestServiceDownBackend

--- a/django_seo_js/backends/base.py
+++ b/django_seo_js/backends/base.py
@@ -16,13 +16,16 @@ IGNORED_HEADERS = frozenset((
 ))
 
 
-class SelectedBackend(MiddlewareMixin):
-
-    def __init__(self, get_response=None, *args, **kwargs):
-        self.get_response = get_response
+class SelectedBackendMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         module_path = settings.BACKEND
         backend_module = importlib.import_module(".".join(module_path.split(".")[:-1]))
         self.backend = getattr(backend_module, module_path.split(".")[-1])()
+
+
+class SelectedBackend(MiddlewareMixin, SelectedBackendMixin):
+    pass
 
 
 class SEOBackendBase:

--- a/django_seo_js/helpers.py
+++ b/django_seo_js/helpers.py
@@ -1,10 +1,10 @@
 from django_seo_js import settings
-from django_seo_js.backends import SelectedBackend
+from django_seo_js.backends import SelectedBackendMixin
 
 
 def update_cache_for_url(url):
     if settings.ENABLED:
-        selector = SelectedBackend()
+        selector = SelectedBackendMixin()
         return selector.backend.update_url(url)
     return False
 

--- a/django_seo_js/tests/backends/test_base.py
+++ b/django_seo_js/tests/backends/test_base.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
-from django_seo_js.tests.utils import override_settings
-from django_seo_js.backends import PrerenderIO, SelectedBackend, SEOBackendBase, TestBackend
+from django_seo_js.tests.utils import override_settings, get_response_empty
+from django_seo_js.backends import PrerenderIO, SelectedBackend, SelectedBackendMixin, SEOBackendBase, TestBackend
 
 
 class SEOBackendBaseTest(TestCase):
@@ -18,10 +18,14 @@ class SEOBackendBaseTest(TestCase):
 class SelectedBackendTest(TestCase):
 
     def test_default_backend(self):
-        s = SelectedBackend()
+        s_mixin = SelectedBackendMixin()
+        s = SelectedBackend(get_response_empty)
+        self.assertTrue(isinstance(s_mixin.backend, PrerenderIO))
         self.assertTrue(isinstance(s.backend, PrerenderIO))
 
     @override_settings(BACKEND='django_seo_js.backends.TestBackend')
     def test_override_backend(self):
-        s = SelectedBackend()
+        s_mixin = SelectedBackendMixin()
+        s = SelectedBackend(get_response_empty)
+        self.assertTrue(isinstance(s_mixin.backend, TestBackend))
         self.assertTrue(isinstance(s.backend, TestBackend))


### PR DESCRIPTION
@pcraciunoiu I'm so so sorry, it looks like there was another change required that I missed

```
AttributeError: 'UserAgentMiddleware' object has no attribute '_is_coroutine'
```

`SelectedBackend` was missing calling the init of it's parent (and so was missing this `_is_coroutine` added in the django async work)
But doing this meant you cannot just do `SelectedBackend()` as `get_response` is required, so I have created a `SelectedBackendMixin` which can be called in the helper function

Would you be able to review and maybe issue a patch release :pray: 